### PR TITLE
Updated the Mask & Stripper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ a preg_replace abstraction easy-to-remember parameters to reduce frequent googli
      *      alpha - keep the alphabetical characters (case insensitive)
      * 		num - keep the digits (0-9)
      *  	comma - keep commas
+     *      colon - keep the : character
      *  	dot - keep periods
      * 		dash - keep dashes/hyphens
-     *  	space - keep spaces* 
+     *  	space - keep spaces 
      * 
      * @return string
      */
@@ -225,8 +226,6 @@ composer test
 To say thanks, you can share the project on social media or <br />
 
 <a href="https://www.buymeacoffee.com/tDbQ4kg" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
-
-
 
 ## Issues
 Please report all issues in the GitHub Issue tracker

--- a/src/Manny/Mask.php
+++ b/src/Manny/Mask.php
@@ -26,10 +26,10 @@ class Mask
 
     public function __construct($target, $pattern)
     {
-        if (! is_string($target)) {
+        if (!is_string($target)) {
             throw new \InvalidArgumentException('Mask target expected to be string');
         }
-        if (! is_string($pattern)) {
+        if (!is_string($pattern)) {
             throw new \InvalidArgumentException('Mask pattern expected to be string');
         }
 

--- a/src/Manny/Mask.php
+++ b/src/Manny/Mask.php
@@ -26,10 +26,10 @@ class Mask
 
     public function __construct($target, $pattern)
     {
-        if (!is_string($target)) {
+        if (! is_string($target)) {
             throw new \InvalidArgumentException('Mask target expected to be string');
         }
-        if (!is_string($pattern)) {
+        if (! is_string($pattern)) {
             throw new \InvalidArgumentException('Mask pattern expected to be string');
         }
 
@@ -71,6 +71,9 @@ class Mask
                     }
                     $output[] = array_shift($nums);
                 } else {
+                    if (count($alphas) == 0 && count($nums) == 0) {
+                        break;
+                    }
                     $output[] = $char;
                 }
             }

--- a/src/Manny/Stripper.php
+++ b/src/Manny/Stripper.php
@@ -34,22 +34,22 @@ class Stripper
     public $defaults = ['alpha', 'num', 'comma', 'dot', 'space', 'dash', 'colon'];
 
     /**
-     * @param string $text - the subject of our stripping
+     * @param string     $text    - the subject of our stripping
      * @param array|null $options - the selection you'd like to to regex
      */
     public function __construct($text, $options = null)
     {
-        if (! is_string($text)) {
+        if (!is_string($text)) {
             throw new \InvalidArgumentException('Stripper expects a string');
         }
         if (is_null($options)) {
             $options = ['alpha', 'num', 'comma', 'dot', 'space', 'dash'];
-        } elseif (! is_array($options)) {
+        } elseif (!is_array($options)) {
             throw new \InvalidArgumentException('Stripper Options must be an array or NULL');
         }
 
         //check that stripper has atleast one option in the array
-        if (! (
+        if (!(
             in_array('alpha', $options) ||
             in_array('num', $options) ||
             in_array('comma', $options) ||
@@ -73,13 +73,13 @@ class Stripper
     private function getRegExString()
     {
         return '/[^'
-            . (in_array('alpha', $this->options) ? 'a-zA-Z' : '')
-            . (in_array('num', $this->options) ? '0-9' : '')
-            . (in_array('comma', $this->options) ? ',' : '')
-            . (in_array('dot', $this->options) ? "\." : '')
-            . (in_array('dash', $this->options) ? "\-" : '')
-            . (in_array('space', $this->options) ? ' ' : '')
-            . (in_array('colon', $this->options) ? ':' : '')
-            . ']/';
+            .(in_array('alpha', $this->options) ? 'a-zA-Z' : '')
+            .(in_array('num', $this->options) ? '0-9' : '')
+            .(in_array('comma', $this->options) ? ',' : '')
+            .(in_array('dot', $this->options) ? "\." : '')
+            .(in_array('dash', $this->options) ? "\-" : '')
+            .(in_array('space', $this->options) ? ' ' : '')
+            .(in_array('colon', $this->options) ? ':' : '')
+            .']/';
     }
 }

--- a/src/Manny/Stripper.php
+++ b/src/Manny/Stripper.php
@@ -10,52 +10,53 @@ namespace Manny;
  *
  * Use Many today for some of these common functions!
  *
- * 	remove all non-digits from string
- * 	Manny::stripper("With only 5-10 hours of development, Dave built Manny, saving him atleast 10 seconds per day!", ['num']);
+ *    remove all non-digits from string
+ *    Manny::stripper("With only 5-10 hours of development, Dave built Manny, saving him atleast 10 seconds per day!", ['num']);
  *  //Outputs: `51010`
  *
  *  just want the letters, numbers and spaces?
  *  Manny::stripper("With only 5-10 hours of development, Dave built Manny, saving him atleast 10 seconds per day!",
- * 					['num', 'alpha','space']);
+ *                    ['num', 'alpha','space']);
  *  //Outputs: `With only 510 hours of development Dave built Manny saving him atleast 10 seconds per day`
  *
- *	Available options are
- *  	alpha - keep the alphabetical characters (case insensitive)
- * 		num - keep the digits (0-9)
- *  	comma - keep commas
- *  	dot - keep periods
- * 		dash - keep dashes/hyphens
- *  	space - keep spaces
+ *    Available options are
+ *    alpha - keep the alphabetical characters (case insensitive)
+ *    num - keep the digits (0-9)
+ *    comma - keep commas
+ *    dot - keep periods
+ *    dash - keep dashes/hyphens
+ *    space - keep spaces
  */
 class Stripper
 {
     public $text;
     public $options;
-    public $defaults = ['alpha', 'num', 'comma', 'dot', 'space', 'dash'];
+    public $defaults = ['alpha', 'num', 'comma', 'dot', 'space', 'dash', 'colon'];
 
     /**
-     * @param string     $text    - the subject of our stripping
+     * @param string $text - the subject of our stripping
      * @param array|null $options - the selection you'd like to to regex
      */
     public function __construct($text, $options = null)
     {
-        if (!is_string($text)) {
+        if (! is_string($text)) {
             throw new \InvalidArgumentException('Stripper expects a string');
         }
         if (is_null($options)) {
             $options = ['alpha', 'num', 'comma', 'dot', 'space', 'dash'];
-        } elseif (!is_array($options)) {
+        } elseif (! is_array($options)) {
             throw new \InvalidArgumentException('Stripper Options must be an array or NULL');
         }
 
         //check that stripper has atleast one option in the array
-        if (!(
+        if (! (
             in_array('alpha', $options) ||
-                in_array('num', $options) ||
-                in_array('comma', $options) ||
-                in_array('dot', $options) ||
-                in_array('space', $options) ||
-                in_array('dash', $options)
+            in_array('num', $options) ||
+            in_array('comma', $options) ||
+            in_array('dot', $options) ||
+            in_array('space', $options) ||
+            in_array('dash', $options) ||
+            in_array('colon', $options)
         )) {
             throw new \InvalidArgumentException('strip function requires atleast one option');
         }
@@ -72,12 +73,13 @@ class Stripper
     private function getRegExString()
     {
         return '/[^'
-                    .(in_array('alpha', $this->options) ? 'a-zA-Z' : '')
-                    .(in_array('num', $this->options) ? '0-9' : '')
-                    .(in_array('comma', $this->options) ? ',' : '')
-                    .(in_array('dot', $this->options) ? "\." : '')
-                    .(in_array('dash', $this->options) ? "\-" : '')
-                    .(in_array('space', $this->options) ? ' ' : '')
-                .']/';
+            . (in_array('alpha', $this->options) ? 'a-zA-Z' : '')
+            . (in_array('num', $this->options) ? '0-9' : '')
+            . (in_array('comma', $this->options) ? ',' : '')
+            . (in_array('dot', $this->options) ? "\." : '')
+            . (in_array('dash', $this->options) ? "\-" : '')
+            . (in_array('space', $this->options) ? ' ' : '')
+            . (in_array('colon', $this->options) ? ':' : '')
+            . ']/';
     }
 }

--- a/tests/MaskTest.php
+++ b/tests/MaskTest.php
@@ -51,4 +51,16 @@ class MaskTest extends TestCase
 
         $this->assertEquals(Manny::mask($target, $config), $good);
     }
+
+    public function test_partial_phone_mask()
+    {
+        //This one is important if someone is doing a phone mask and wants to have an optional extension
+        // Eg. user enters 111-111-1111 and the mask is 111-111-1111 ext. 1111 - if you enter in 111-111-1111 it should return with that.
+
+        $target = '111 111';
+        $config = '111-111-1111';
+        $good = '111-111';
+
+        $this->assertEquals(Manny::mask($target, $config), $good);
+    }
 }

--- a/tests/StripperTest.php
+++ b/tests/StripperTest.php
@@ -24,4 +24,13 @@ class StripperTest extends TestCase
 
         $this->assertEquals(Manny::stripper($target, $config), $good);
     }
+
+    public function test_stripper_3()
+    {
+        $target = 'invoice: AQ&*(*&(* 12345';
+        $config = ['alpha', 'num', 'colon'];
+        $good = 'invoice:AQ12345';
+
+        $this->assertEquals(Manny::stripper($target, $config), $good);
+    }
 }


### PR DESCRIPTION
Updated Mask to not add on additional characters after we've run out of characters.

eg:
```php
Manny::mask('123-123-1234', '111-111-1111 ext. 111111111');
// Before
// returns "123-123-1234 ext. "

// After
// returns "123-123-1234"
```

Added the "colon" option for the Stripper function which preserves the colon character in the text
eg:
```php
Manny::mask('Invoice Number: 123123', ['colon', 'num']);
// returns ":123123"
```